### PR TITLE
Reflect openSUSE Container defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # cooverview
-Container Overview - A simple CGI script to read container information from a docker registry and display it
+Container Overview - A simple CGI script to read container information from an OCI container registry and display it

--- a/cooverview
+++ b/cooverview
@@ -66,7 +66,7 @@ sub create_details_html {
   my $tags = [];
   my $info;
 
-  my $pull_prefix="docker pull $config->{pull_host}".(($config->{pull_port}) ? ":$config->{pull_port}/" : "/");
+  my $pull_prefix="podman pull $config->{pull_host}".(($config->{pull_port}) ? ":$config->{pull_port}/" : "/");
 
   my $data = {
     name => $rep,

--- a/templates/header.tt2
+++ b/templates/header.tt2
@@ -1,10 +1,10 @@
     <div class=jumbotron>
-      <h1>SUSE Container Registry/Notary</h1>
+      <h1>openSUSE Container Registry/Notary</h1>
       <h2>Container Images built by OBS</h2>
       <p>You can click on the blue boxes to get detailed information about the
          container image including the known tags and included layers. In the
          grey boxes you will find a complete command line to pull the images into
-         your local docker environment.
+         your local podman environment.
       </p>
       <p>
         For comments or bugreports, feel free to open an issue on <a href="https://github.com/M0ses/cooverview/issues">GitHub</a>


### PR DESCRIPTION
Podman is the default container runtime of Kubic, openSUSE's kubernetes certified distribution

So our registry should better reflect our recommend defaults, and where appropriate use generic terms like 'OCI Container' instead of 'docker'

Solves https://github.com/M0ses/cooverview/issues/1 and https://github.com/M0ses/cooverview/issues/4