### PR TITLE
href to obs project (fix: #3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,11 @@ css:
 
 config:
 	[ -d $(DESTDIR)/etc/cooverview ] || mkdir -p $(DESTDIR)/etc/cooverview
-	install -m 644 ./config.yml.template $(DESTDIR)/etc/cooverview/config.yml
+	@if [ -f ./config.yml ];then \
+		install -m 644 ./config.yml $(DESTDIR)/etc/cooverview/config.yml;\
+	else \
+		install -m 644 ./config.yml.template $(DESTDIR)/etc/cooverview/config.yml;\
+	fi
 
 templates:
 	[ -d $(DESTDIR)/etc/cooverview/templates ] || \

--- a/config.yml.template
+++ b/config.yml.template
@@ -1,5 +1,11 @@
+templates_dir: /etc/cooverview/templates
 proto: https
 host: test-registry
 port: 443
 user: myuser
 pass: mypass
+pull_host: registry.opensuse.org
+use_obs_extended_info: 1
+build_host:
+  host: build.opensuse.org
+  # proto: https

--- a/cooverview
+++ b/cooverview
@@ -90,6 +90,9 @@ sub create_details_html {
     if ($config->{use_obs_extended_info}) {
       $data->{info} = $drc->obs_info_json($rep);
       $data->{project} = $data->{info}->{project};
+      if ($config->{build_host}) {
+        $data->{project_href} = ($config->{build_host}->{proto} || 'https')."://$config->{build_host}->{host}/project/show/$data->{info}->{project}";
+      }
       $data->{repository} = $data->{info}->{repository};
       foreach my $tag_val (values %{$data->{info}->{tags}}) {
          foreach my $img (@{$tag_val->{images}}) {

--- a/templates/details.tt2
+++ b/templates/details.tt2
@@ -17,7 +17,11 @@
            <b>Project:</b>
          </div>
          <div class=col-md-11>
+           [% IF project_href %]
+           <a href="[% project_href %]" target="_blank">[% project %]</a>
+           [% ELSE %]
            [% project %]
+           [% END %]
          </div>
        </div>
 


### PR DESCRIPTION
if set "use_obs_extended_info" to true and a "build_host" configuration in
config.yml a link (href) to the project is created in detailed view.